### PR TITLE
Add KDE's systemsettings to depend ilst.

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -30,6 +30,7 @@ Package: lingmo-kwin-plugins-roundedwindow
 Architecture: any
 Depends: qml-module-qtquick-controls2,
          qml-module-qtquick2,
+         systemsettings,
          ${misc:Depends},
          ${shlibs:Depends}
 Description: LingmoOS KWin Plugins - Rounded Window


### PR DESCRIPTION
Round corner plugin currently needs KCM, provided by systemsettings. 

This will be fixed by changed the method of reading configurations..